### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/lolan_bms_ble/button/lolan_button.cpp
+++ b/components/lolan_bms_ble/button/lolan_button.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace lolan_bms_ble {
+namespace esphome::lolan_bms_ble {
 
 static const char *const TAG = "lolan_bms_ble.button";
 
@@ -19,5 +18,4 @@ void LolanButton::press_action() {
   this->parent_->send_command(this->holding_register_);
 }
 
-}  // namespace lolan_bms_ble
-}  // namespace esphome
+}  // namespace esphome::lolan_bms_ble

--- a/components/lolan_bms_ble/button/lolan_button.h
+++ b/components/lolan_bms_ble/button/lolan_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace lolan_bms_ble {
+namespace esphome::lolan_bms_ble {
 
 class LolanBmsBle;
 class LolanButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class LolanButton : public button::Button, public Component {
   uint16_t holding_register_;
 };
 
-}  // namespace lolan_bms_ble
-}  // namespace esphome
+}  // namespace esphome::lolan_bms_ble

--- a/components/lolan_bms_ble/lolan_bms_ble.cpp
+++ b/components/lolan_bms_ble/lolan_bms_ble.cpp
@@ -9,8 +9,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace lolan_bms_ble {
+namespace esphome::lolan_bms_ble {
 
 static const char *const TAG = "lolan_bms_ble";
 
@@ -666,5 +665,4 @@ std::string LolanBmsBle::bitmask_to_string_(const char *const messages[], const 
   return values;
 }
 
-}  // namespace lolan_bms_ble
-}  // namespace esphome
+}  // namespace esphome::lolan_bms_ble

--- a/components/lolan_bms_ble/lolan_bms_ble.h
+++ b/components/lolan_bms_ble/lolan_bms_ble.h
@@ -13,8 +13,7 @@
 namespace espbt = esphome::esp32_ble_tracker;
 #endif
 
-namespace esphome {
-namespace lolan_bms_ble {
+namespace esphome::lolan_bms_ble {
 
 class LolanBmsBle :
 #ifdef USE_ESP32
@@ -182,5 +181,4 @@ class LolanBmsBle :
   }
 };
 
-}  // namespace lolan_bms_ble
-}  // namespace esphome
+}  // namespace esphome::lolan_bms_ble

--- a/components/lolan_bms_ble/switch/lolan_switch.cpp
+++ b/components/lolan_bms_ble/switch/lolan_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace lolan_bms_ble {
+namespace esphome::lolan_bms_ble {
 
 static const char *const TAG = "lolan_bms_ble.switch";
 
@@ -14,5 +13,4 @@ void LolanSwitch::write_state(bool state) {
   }
 }
 
-}  // namespace lolan_bms_ble
-}  // namespace esphome
+}  // namespace esphome::lolan_bms_ble

--- a/components/lolan_bms_ble/switch/lolan_switch.h
+++ b/components/lolan_bms_ble/switch/lolan_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace lolan_bms_ble {
+namespace esphome::lolan_bms_ble {
 
 class LolanBmsBle;
 class LolanSwitch : public switch_::Switch, public Component {
@@ -24,5 +23,4 @@ class LolanSwitch : public switch_::Switch, public Component {
   uint16_t command_turn_off_;
 };
 
-}  // namespace lolan_bms_ble
-}  // namespace esphome
+}  // namespace esphome::lolan_bms_ble


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.