### PR TITLE
Fix redundant string initialization

### DIFF
--- a/components/lolan_bms_ble/lolan_bms_ble.cpp
+++ b/components/lolan_bms_ble/lolan_bms_ble.cpp
@@ -650,7 +650,7 @@ bool LolanBmsBle::send_factory_reset() { return false; }
 
 std::string LolanBmsBle::bitmask_to_string_(const char *const messages[], const uint8_t &messages_size,
                                             const uint8_t &mask) {
-  std::string values = "";
+  std::string values;
   if (mask) {
     for (int i = 0; i < messages_size; i++) {
       if (mask & (1 << i)) {


### PR DESCRIPTION
Remove redundant empty string initialization (`= ""`) flagged by `readability-redundant-string-init`. `std::string` default-constructs to an empty string.