### PR TITLE
Add online_status sensor with unavailability tracking

### DIFF
--- a/components/lolan_bms_ble/binary_sensor.py
+++ b/components/lolan_bms_ble/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import LOLAN_BMS_BLE_COMPONENT_SCHEMA
 
@@ -11,9 +11,14 @@ CODEOWNERS = ["@syssi"]
 
 CONF_CHARGING = "charging"
 CONF_DISCHARGING = "discharging"
+CONF_ONLINE_STATUS = "online_status"
 
 # key: binary_sensor_schema kwargs
 BINARY_SENSOR_DEFS = {
+    CONF_ONLINE_STATUS: {
+        "device_class": DEVICE_CLASS_CONNECTIVITY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
     CONF_CHARGING: {
         "icon": "mdi:battery-charging",
         "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,

--- a/components/lolan_bms_ble/lolan_bms_ble.cpp
+++ b/components/lolan_bms_ble/lolan_bms_ble.cpp
@@ -566,8 +566,6 @@ void LolanBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
     case ESP_GATTC_DISCONNECT_EVT: {
       this->node_state = espbt::ClientState::IDLE;
 
-      // this->publish_state_(this->voltage_sensor_, NAN);
-
       if (this->char_notify_handle_ != 0) {
         auto status = esp_ble_gattc_unregister_for_notify(this->parent()->get_gattc_if(),
                                                           this->parent()->get_remote_bda(), this->char_notify_handle_);

--- a/components/lolan_bms_ble/lolan_bms_ble.cpp
+++ b/components/lolan_bms_ble/lolan_bms_ble.cpp
@@ -12,6 +12,7 @@
 namespace esphome::lolan_bms_ble {
 
 static const char *const TAG = "lolan_bms_ble";
+static const uint8_t MAX_NO_RESPONSE_COUNT = 10;
 
 static const uint16_t LOLAN_BMS_SERVICE_UUID = 0xFFE0;
 static const uint16_t LOLAN_BMS_SERVICE_UUID2 = 0xFFF0;
@@ -82,6 +83,7 @@ static uint16_t crc16_lolan(const uint8_t *data, size_t size) {
 }
 
 void LolanBmsBle::on_lolan_bms_ble_data(const uint8_t &handle, const std::vector<uint8_t> &data) {
+  this->reset_online_status_tracker_();
   if (data.size() > MAX_RESPONSE_SIZE) {
     ESP_LOGW(TAG, "Invalid response received: %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
     return;
@@ -438,6 +440,7 @@ void LolanBmsBle::decode_confirmations_(const std::vector<uint8_t> &data) {
 void LolanBmsBle::dump_config() {  // NOLINT(google-readability-function-size,readability-function-size)
   ESP_LOGCONFIG(TAG, "LolanBmsBle:");
 
+  LOG_BINARY_SENSOR("", "Online Status", this->online_status_binary_sensor_);
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Discharging", this->discharging_binary_sensor_);
 
@@ -480,6 +483,48 @@ void LolanBmsBle::dump_config() {  // NOLINT(google-readability-function-size,re
 
   LOG_TEXT_SENSOR("", "Errors", this->errors_text_sensor_);
   LOG_TEXT_SENSOR("", "Total runtime formatted", this->total_runtime_formatted_text_sensor_);
+}
+
+void LolanBmsBle::track_online_status_() {
+  if (this->no_response_count_ < MAX_NO_RESPONSE_COUNT)
+    this->no_response_count_++;
+  if (this->no_response_count_ == MAX_NO_RESPONSE_COUNT) {
+    this->publish_device_unavailable_();
+    this->no_response_count_++;
+  }
+}
+
+void LolanBmsBle::reset_online_status_tracker_() {
+  this->no_response_count_ = 0;
+  this->publish_state_(this->online_status_binary_sensor_, true);
+}
+
+void LolanBmsBle::publish_device_unavailable_() {
+  this->publish_state_(this->online_status_binary_sensor_, false);
+  this->publish_state_(this->total_voltage_sensor_, NAN);
+  this->publish_state_(this->current_sensor_, NAN);
+  this->publish_state_(this->power_sensor_, NAN);
+  this->publish_state_(this->charging_power_sensor_, NAN);
+  this->publish_state_(this->discharging_power_sensor_, NAN);
+  this->publish_state_(this->error_bitmask_sensor_, NAN);
+  this->publish_state_(this->state_of_charge_sensor_, NAN);
+  this->publish_state_(this->charging_cycles_sensor_, NAN);
+  this->publish_state_(this->min_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->max_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->min_voltage_cell_sensor_, NAN);
+  this->publish_state_(this->max_voltage_cell_sensor_, NAN);
+  this->publish_state_(this->delta_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->average_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->total_runtime_sensor_, NAN);
+  this->publish_state_(this->balancer_voltage_sensor_, NAN);
+  this->publish_state_(this->total_charged_capacity_sensor_, NAN);
+  this->publish_state_(this->total_discharged_capacity_sensor_, NAN);
+  for (auto &cell : this->cells_)
+    this->publish_state_(cell.cell_voltage_sensor_, NAN);
+  for (auto &temp : this->temperatures_)
+    this->publish_state_(temp.temperature_sensor_, NAN);
+  this->publish_state_(this->errors_text_sensor_, "Offline");
+  this->publish_state_(this->total_runtime_formatted_text_sensor_, "Offline");
 }
 
 void LolanBmsBle::publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state) {
@@ -582,6 +627,7 @@ void LolanBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
 }
 
 void LolanBmsBle::update() {
+  this->track_online_status_();
   if (this->node_state != espbt::ClientState::ESTABLISHED) {
     ESP_LOGW(TAG, "[%s] Not connected", ADDR_STR(this->parent_->address_str()));
     return;

--- a/components/lolan_bms_ble/lolan_bms_ble.h
+++ b/components/lolan_bms_ble/lolan_bms_ble.h
@@ -29,6 +29,9 @@ class LolanBmsBle :
   void update() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
 
+  void set_online_status_binary_sensor(binary_sensor::BinarySensor *online_status_binary_sensor) {
+    online_status_binary_sensor_ = online_status_binary_sensor;
+  }
   void set_charging_binary_sensor(binary_sensor::BinarySensor *charging_binary_sensor) {
     charging_binary_sensor_ = charging_binary_sensor;
   }
@@ -101,6 +104,7 @@ class LolanBmsBle :
   void set_password(uint32_t password) { this->password_ = password; }
 
  protected:
+  binary_sensor::BinarySensor *online_status_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *charging_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *discharging_binary_sensor_{nullptr};
 
@@ -137,6 +141,7 @@ class LolanBmsBle :
     sensor::Sensor *temperature_sensor_{nullptr};
   } temperatures_[2];
 
+  uint8_t no_response_count_{0};
   uint16_t char_notify_handle_{0};
   uint16_t char_command_handle_{0};
   uint32_t password_ = 12345678;
@@ -145,6 +150,9 @@ class LolanBmsBle :
   void decode_status_data_(const std::vector<uint8_t> &data);
   void decode_cell_info_data_(const std::vector<uint8_t> &data);
   void decode_confirmations_(const std::vector<uint8_t> &data);
+  void publish_device_unavailable_();
+  void reset_online_status_tracker_();
+  void track_online_status_();
   void publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(switch_::Switch *obj, const bool &state);

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -71,6 +71,9 @@ lolan_bms_ble:
 binary_sensor:
   - platform: lolan_bms_ble
     lolan_bms_ble_id: bms0
+    online_status:
+      name: "online status"
+      device_id: device0
     charging:
       name: "charging"
       device_id: device0
@@ -80,6 +83,9 @@ binary_sensor:
 
   - platform: lolan_bms_ble
     lolan_bms_ble_id: bms1
+    online_status:
+      name: "online status"
+      device_id: device1
     charging:
       name: "charging"
       device_id: device1

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -62,6 +62,8 @@ lolan_bms_ble:
 binary_sensor:
   - platform: lolan_bms_ble
     lolan_bms_ble_id: bms0
+    online_status:
+      name: "online status"
     charging:
       name: "charging"
     discharging:

--- a/tests/components/lolan_bms_ble/common.h
+++ b/tests/components/lolan_bms_ble/common.h
@@ -8,6 +8,10 @@ namespace esphome::lolan_bms_ble::testing {
 
 class TestableLolanBmsBle : public LolanBmsBle {
  public:
+  using LolanBmsBle::track_online_status_;
+  using LolanBmsBle::reset_online_status_tracker_;
+  using LolanBmsBle::publish_device_unavailable_;
+  uint8_t get_no_response_count() const { return no_response_count_; }
   using LolanBmsBle::decode_cell_info_data_;
   using LolanBmsBle::decode_confirmations_;
   using LolanBmsBle::decode_settings_data_;

--- a/tests/components/lolan_bms_ble/lolan_bms_ble_test.cpp
+++ b/tests/components/lolan_bms_ble/lolan_bms_ble_test.cpp
@@ -262,4 +262,163 @@ TEST(LolanBmsBleButtonTest, FactoryResetCommandSent) {
   button.press();
 }
 
+// ── Online status tracker ─────────────────────────────────────────────────────
+
+TEST(LolanBmsBleOnlineStatusTrackerTest, ReachesThreshold) {
+  TestableLolanBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+
+  EXPECT_FALSE(online_status.state);
+}
+
+TEST(LolanBmsBleOnlineStatusTrackerTest, DoesNotRepeatAfterThreshold) {
+  TestableLolanBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  EXPECT_EQ(bms.get_no_response_count(), 11);
+
+  bms.track_online_status_();
+  EXPECT_EQ(bms.get_no_response_count(), 11);
+}
+
+TEST(LolanBmsBleOnlineStatusTrackerTest, ResetRestoresOnlineStatus) {
+  TestableLolanBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  EXPECT_FALSE(online_status.state);
+
+  bms.reset_online_status_tracker_();
+  EXPECT_TRUE(online_status.state);
+  EXPECT_EQ(bms.get_no_response_count(), 0);
+}
+
+TEST(LolanBmsBleOnlineStatusTrackerTest, CanRetriggerAfterReset) {
+  TestableLolanBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  bms.reset_online_status_tracker_();
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  EXPECT_FALSE(online_status.state);
+}
+
+TEST(LolanBmsBleOnlineStatusTrackerTest, ValidFrameResetsCounter) {
+  TestableLolanBmsBle bms;
+
+  for (int i = 0; i < 5; i++)
+    bms.track_online_status_();
+  EXPECT_EQ(bms.get_no_response_count(), 5);
+
+  bms.on_lolan_bms_ble_data(0x00, STATUS_FRAME_CHARGING_AND_DISCHARGING);
+  EXPECT_EQ(bms.get_no_response_count(), 0);
+}
+
+TEST(LolanBmsBleOnlineStatusTrackerTest, NotYetAtThresholdStaysOnline) {
+  TestableLolanBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  online_status.publish_state(true);
+  for (int i = 0; i < 9; i++)
+    bms.track_online_status_();
+
+  EXPECT_TRUE(online_status.state);
+}
+
+// ── publish_device_unavailable_ ───────────────────────────────────────────────
+
+TEST(LolanBmsBlePublishDeviceUnavailableTest, SetsOnlineStatusFalse) {
+  TestableLolanBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  online_status.publish_state(true);
+  bms.publish_device_unavailable_();
+
+  EXPECT_FALSE(online_status.state);
+}
+
+TEST(LolanBmsBlePublishDeviceUnavailableTest, SetsNumericSensorsToNAN) {
+  TestableLolanBmsBle bms;
+  sensor::Sensor total_voltage, current, power, charging_power, discharging_power;
+  sensor::Sensor error_bitmask, state_of_charge, charging_cycles, total_runtime, balancer_voltage;
+  bms.set_total_voltage_sensor(&total_voltage);
+  bms.set_current_sensor(&current);
+  bms.set_power_sensor(&power);
+  bms.set_charging_power_sensor(&charging_power);
+  bms.set_discharging_power_sensor(&discharging_power);
+  bms.set_error_bitmask_sensor(&error_bitmask);
+  bms.set_state_of_charge_sensor(&state_of_charge);
+  bms.set_charging_cycles_sensor(&charging_cycles);
+  bms.set_total_runtime_sensor(&total_runtime);
+  bms.set_balancer_voltage_sensor(&balancer_voltage);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_TRUE(std::isnan(total_voltage.state));
+  EXPECT_TRUE(std::isnan(current.state));
+  EXPECT_TRUE(std::isnan(power.state));
+  EXPECT_TRUE(std::isnan(charging_power.state));
+  EXPECT_TRUE(std::isnan(discharging_power.state));
+  EXPECT_TRUE(std::isnan(error_bitmask.state));
+  EXPECT_TRUE(std::isnan(state_of_charge.state));
+  EXPECT_TRUE(std::isnan(charging_cycles.state));
+  EXPECT_TRUE(std::isnan(total_runtime.state));
+  EXPECT_TRUE(std::isnan(balancer_voltage.state));
+}
+
+TEST(LolanBmsBlePublishDeviceUnavailableTest, SetsCellAndTempSensorsToNAN) {
+  TestableLolanBmsBle bms;
+  sensor::Sensor cell0, cell1, temp0, temp1;
+  bms.set_cell_voltage_sensor(0, &cell0);
+  bms.set_cell_voltage_sensor(1, &cell1);
+  bms.set_temperature_sensor(0, &temp0);
+  bms.set_temperature_sensor(1, &temp1);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_TRUE(std::isnan(cell0.state));
+  EXPECT_TRUE(std::isnan(cell1.state));
+  EXPECT_TRUE(std::isnan(temp0.state));
+  EXPECT_TRUE(std::isnan(temp1.state));
+}
+
+TEST(LolanBmsBlePublishDeviceUnavailableTest, SetsDynamicTextSensorsToOffline) {
+  TestableLolanBmsBle bms;
+  text_sensor::TextSensor errors, total_runtime_formatted;
+  bms.set_errors_text_sensor(&errors);
+  bms.set_total_runtime_formatted_text_sensor(&total_runtime_formatted);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_EQ(errors.state, "Offline");
+  EXPECT_EQ(total_runtime_formatted.state, "Offline");
+}
+
+TEST(LolanBmsBlePublishDeviceUnavailableTest, LeavesStaticTextSensorsUnchanged) {
+  TestableLolanBmsBle bms;
+  // lolan_bms_ble has no static identity text sensors — this test is a no-op
+  EXPECT_NO_FATAL_FAILURE(bms.publish_device_unavailable_());
+}
+
+TEST(LolanBmsBlePublishDeviceUnavailableTest, NullSensorsDoNotCrash) {
+  TestableLolanBmsBle bms;
+
+  EXPECT_NO_FATAL_FAILURE(bms.publish_device_unavailable_());
+}
+
 }  // namespace esphome::lolan_bms_ble::testing

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -59,9 +59,10 @@ class TestSensorLists:
 
 class TestBinarySensorDefs:
     def test_binary_sensor_defs_completeness(self):
+        assert binary_sensor.CONF_ONLINE_STATUS in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_CHARGING in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_DISCHARGING in binary_sensor.BINARY_SENSOR_DEFS
-        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 2
+        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 3
 
 
 class TestTextSensors:


### PR DESCRIPTION
## Summary

- Adds `online_status` binary sensor (`device_class: connectivity`, `entity_category: diagnostic`)
- After 10 consecutive `update()` cycles without a valid BMS frame, marks the device unavailable: `online_status` → false, all numeric sensors → NaN, dynamic text sensors (`errors`, `total_runtime_formatted`) → "Offline"
- No static identity text sensors in this component
- Integrates `track_online_status_()` at the start of `update()` and `reset_online_status_tracker_()` at the entry of `on_lolan_bms_ble_data()`

## Test plan

- [x] C++ unit tests: `LolanBmsBleOnlineStatusTrackerTest` (6 tests) and `LolanBmsBlePublishDeviceUnavailableTest` (6 tests) — all 42 tests pass
- [x] pytest schema validation passes (3 binary sensor defs)
- [x] `esp32-ble-example.yaml` and `esp32-ble-example-multiple-devices.yaml` updated with `online_status` sensor